### PR TITLE
fix: remove no-commit-to-branch linter

### DIFF
--- a/catalog/precommit/pre-commit-config.yaml
+++ b/catalog/precommit/pre-commit-config.yaml
@@ -12,8 +12,6 @@ repos:
         args: ["-f", "lf"]
         exclude: \.bat$
         stages: [commit]
-      - id: no-commit-to-branch
-        stages: [commit]
       - id: check-added-large-files
         stages: [commit]
       - id: check-case-conflict


### PR DESCRIPTION
This removes the `no-commit-to-branch` linter as we've discovered problems with it in: https://github.com/mesosphere/ai-navigator/tree/main